### PR TITLE
Refactor filter controls into reusable modules

### DIFF
--- a/filters/core.py
+++ b/filters/core.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import dataclass
+from typing import Iterable, List, Optional, Sequence, Union
+
+import numpy as np
+import pandas as pd
+
+TIME_INDEX_OPTION = "(time index)"
+
+
+@dataclass
+class DatetimeIndexCondition:
+    logic: str
+    low: Optional[dt.datetime] = None
+    up: Optional[dt.datetime] = None
+
+
+@dataclass
+class DatetimeColumnCondition:
+    logic: str
+    column: str
+    low: Optional[dt.datetime] = None
+    up: Optional[dt.datetime] = None
+
+
+@dataclass
+class NumericRangeCondition:
+    logic: str
+    column: str
+    low: Optional[float] = None
+    up: Optional[float] = None
+
+
+@dataclass
+class CategoricalCondition:
+    logic: str
+    column: str
+    op: str
+    values: Sequence[str]
+    case_sensitive: bool = False
+    na_match: bool = False
+
+
+Condition = Union[
+    DatetimeIndexCondition,
+    DatetimeColumnCondition,
+    NumericRangeCondition,
+    CategoricalCondition,
+]
+
+
+def infer_filterable_columns(df: pd.DataFrame, include_index: bool = True) -> dict:
+    """Return the inferred filterable columns grouped by semantic type."""
+    is_dt_index = include_index and isinstance(df.index, pd.DatetimeIndex)
+    num_cols = df.select_dtypes(include=[np.number]).columns.tolist()
+    dt_cols = df.select_dtypes(include=["datetime", "datetimetz"]).columns.tolist()
+    cat_cols = df.select_dtypes(include=["object", "category", "bool"]).columns.tolist()
+
+    filter_vars: List[str] = []
+    if is_dt_index:
+        filter_vars.append(TIME_INDEX_OPTION)
+    filter_vars.extend(dt_cols)
+    filter_vars.extend(num_cols)
+    filter_vars.extend(cat_cols)
+
+    return {
+        "is_datetime_index": is_dt_index,
+        "datetime": dt_cols,
+        "numeric": num_cols,
+        "categorical": cat_cols,
+        "options": filter_vars,
+    }
+
+
+def _align_to_tz(ts: Optional[dt.datetime], tz) -> Optional[pd.Timestamp]:
+    if ts is None:
+        return None
+    ts = pd.Timestamp(ts)
+    if tz is not None:
+        return ts.tz_localize(tz) if ts.tzinfo is None else ts.tz_convert(tz)
+    else:
+        return ts.tz_localize(None) if ts.tzinfo is not None else ts
+
+
+def _categorical_noop(cond: CategoricalCondition) -> bool:
+    op = cond.op
+    vals = list(cond.values)
+    if op in {"is one of", "is not one of"}:
+        return len(vals) == 0
+    if op in {"contains", "not contains", "starts with", "ends with", "regex"}:
+        return len(vals) == 0 or (len(vals) == 1 and vals[0] == "")
+    return False
+
+
+def build_mask(df: pd.DataFrame, conditions: Iterable[Condition]) -> pd.Series:
+    mask = pd.Series(True, index=df.index)
+    first = True
+
+    for cond in conditions:
+        if isinstance(cond, DatetimeIndexCondition):
+            if cond.low is None and cond.up is None:
+                continue
+            series = df.index
+            tz = getattr(series, "tz", None)
+            low = _align_to_tz(cond.low, tz)
+            up = _align_to_tz(cond.up, tz)
+            cond_mask = pd.Series(True, index=df.index)
+            if low is not None:
+                cond_mask &= series >= low
+            if up is not None:
+                cond_mask &= series <= up
+
+        elif isinstance(cond, DatetimeColumnCondition):
+            if cond.low is None and cond.up is None:
+                continue
+            series = pd.to_datetime(df[cond.column], errors="coerce")
+            tz = getattr(series.dt, "tz", None)
+            low = _align_to_tz(cond.low, tz)
+            up = _align_to_tz(cond.up, tz)
+            cond_mask = pd.Series(True, index=df.index)
+            if low is not None:
+                cond_mask &= series >= low
+            if up is not None:
+                cond_mask &= series <= up
+
+        elif isinstance(cond, NumericRangeCondition):
+            if cond.low is None and cond.up is None:
+                continue
+            series = df[cond.column]
+            if not pd.api.types.is_numeric_dtype(series):
+                series = pd.to_numeric(series, errors="coerce")
+            cond_mask = pd.Series(True, index=df.index)
+            if cond.low is not None:
+                cond_mask &= series >= cond.low
+            if cond.up is not None:
+                cond_mask &= series <= cond.up
+
+        else:  # categorical
+            if _categorical_noop(cond):
+                continue
+            series = df[cond.column].astype("string")
+            op = cond.op
+            vals = list(cond.values)
+            case = cond.case_sensitive
+            na_match = cond.na_match
+            cond_mask = pd.Series(False, index=df.index)
+
+            if op in {"is one of", "is not one of"}:
+                base = series.isin(vals)
+                cond_mask = base.fillna(na_match)
+                if op == "is not one of":
+                    cond_mask = ~cond_mask
+
+            elif op in {"contains", "not contains"}:
+                patt = vals[0]
+                if not case:
+                    series_cmp = series.str.lower()
+                    patt = patt.lower()
+                else:
+                    series_cmp = series
+                base = series_cmp.str.contains(patt, regex=False, na=na_match)
+                cond_mask = base if op == "contains" else ~base
+
+            elif op in {"starts with", "ends with"}:
+                patt = vals[0]
+                if not case:
+                    series_cmp = series.str.lower()
+                    patt = patt.lower()
+                else:
+                    series_cmp = series
+                if op == "starts with":
+                    cond_mask = series_cmp.str.startswith(patt, na=na_match)
+                else:
+                    cond_mask = series_cmp.str.endswith(patt, na=na_match)
+
+            else:  # regex
+                patt = vals[0]
+                cond_mask = series.str.contains(patt, regex=True, case=case, na=na_match)
+
+            if na_match:
+                cond_mask = cond_mask | series.isna()
+
+        if first:
+            mask = cond_mask
+            first = False
+        else:
+            if cond.logic == "AND":
+                mask = mask & cond_mask
+            else:
+                mask = mask | cond_mask
+
+    return mask

--- a/filters/ui.py
+++ b/filters/ui.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+import datetime as dt
+from typing import List
+
+import pandas as pd
+import streamlit as st
+
+from .core import (
+    CategoricalCondition,
+    Condition,
+    DatetimeColumnCondition,
+    DatetimeIndexCondition,
+    NumericRangeCondition,
+    TIME_INDEX_OPTION,
+    infer_filterable_columns,
+)
+
+
+def _parse_csv_list(s: str) -> List[str]:
+    return [v.strip() for v in s.split(",") if v.strip()]
+
+
+def _default_year_from_series(series: pd.Series, fallback: int) -> int:
+    try:
+        ts = pd.to_datetime(series, errors="coerce").dropna()
+        if len(ts) == 0:
+            return fallback
+        return int(ts.max().year)
+    except Exception:
+        return fallback
+
+
+def render_filter_controls(
+    df: pd.DataFrame,
+    key_prefix: str = "flt",
+    allow_time_index: bool = True,
+) -> List[Condition]:
+    """Render Streamlit controls for filters and return selected conditions."""
+    info = infer_filterable_columns(df, include_index=allow_time_index)
+
+    is_dt_index = info["is_datetime_index"]
+    options = info["options"]
+    dt_cols = set(info["datetime"])
+    num_cols = set(info["numeric"])
+    cat_cols = set(info["categorical"])
+
+    if is_dt_index and len(df.index) > 0:
+        default_year = int(pd.Timestamp(df.index.max()).year)
+    else:
+        default_year = dt.date.today().year
+
+    n_filters = st.number_input(
+        "Number of filtering conditions",
+        min_value=0,
+        max_value=10,
+        value=0,
+        step=1,
+        key=f"{key_prefix}_n",
+        help="Each condition matches rows; you can chain with AND/OR. Empty numeric bounds mean −∞ / +∞.",
+    )
+
+    conditions: List[Condition] = []
+
+    for i in range(int(n_filters)):
+        with st.expander(f"Condition {i+1}", expanded=True):
+            logic_op = st.selectbox(
+                "Logical operator vs previous",
+                ["AND", "OR"],
+                index=0,
+                key=f"{key_prefix}_logic_{i}",
+            )
+            var_i = st.selectbox(
+                "Variable",
+                options=options,
+                index=0,
+                key=f"{key_prefix}_var_{i}",
+            )
+
+            if var_i == TIME_INDEX_OPTION:
+                use_low = st.checkbox(
+                    "Set lower datetime bound (≥)",
+                    value=False,
+                    key=f"{key_prefix}_use_lowdt_idx_{i}",
+                )
+                if use_low:
+                    low_date = st.date_input(
+                        "Lower date",
+                        value=dt.date(default_year, 1, 1),
+                        key=f"{key_prefix}_low_date_idx_{i}",
+                    )
+                    low_time = st.time_input(
+                        "Lower time",
+                        value=dt.time(0, 0),
+                        key=f"{key_prefix}_low_time_idx_{i}",
+                    )
+                    low_val = dt.datetime.combine(low_date, low_time)
+                else:
+                    low_val = None
+
+                use_up = st.checkbox(
+                    "Set upper datetime bound (≤)",
+                    value=False,
+                    key=f"{key_prefix}_use_updt_idx_{i}",
+                )
+                if use_up:
+                    up_date = st.date_input(
+                        "Upper date",
+                        value=dt.date(default_year, 12, 31),
+                        key=f"{key_prefix}_up_date_idx_{i}",
+                    )
+                    up_time = st.time_input(
+                        "Upper time",
+                        value=dt.time(23, 59, 59),
+                        key=f"{key_prefix}_up_time_idx_{i}",
+                    )
+                    up_val = dt.datetime.combine(up_date, up_time)
+                else:
+                    up_val = None
+
+                conditions.append(
+                    DatetimeIndexCondition(
+                        logic=logic_op,
+                        low=low_val,
+                        up=up_val,
+                    )
+                )
+
+            elif var_i in dt_cols:
+                col = df[var_i]
+                col_year = _default_year_from_series(col, default_year)
+
+                use_low = st.checkbox(
+                    "Set lower datetime bound (≥)",
+                    value=False,
+                    key=f"{key_prefix}_use_lowdt_col_{i}",
+                )
+                if use_low:
+                    low_date = st.date_input(
+                        "Lower date",
+                        value=dt.date(col_year, 1, 1),
+                        key=f"{key_prefix}_low_date_col_{i}",
+                    )
+                    low_time = st.time_input(
+                        "Lower time",
+                        value=dt.time(0, 0),
+                        key=f"{key_prefix}_low_time_col_{i}",
+                    )
+                    low_val = dt.datetime.combine(low_date, low_time)
+                else:
+                    low_val = None
+
+                use_up = st.checkbox(
+                    "Set upper datetime bound (≤)",
+                    value=False,
+                    key=f"{key_prefix}_use_updt_col_{i}",
+                )
+                if use_up:
+                    up_date = st.date_input(
+                        "Upper date",
+                        value=dt.date(col_year, 12, 31),
+                        key=f"{key_prefix}_up_date_col_{i}",
+                    )
+                    up_time = st.time_input(
+                        "Upper time",
+                        value=dt.time(23, 59, 59),
+                        key=f"{key_prefix}_up_time_col_{i}",
+                    )
+                    up_val = dt.datetime.combine(up_date, up_time)
+                else:
+                    up_val = None
+
+                conditions.append(
+                    DatetimeColumnCondition(
+                        logic=logic_op,
+                        column=var_i,
+                        low=low_val,
+                        up=up_val,
+                    )
+                )
+
+            elif var_i in num_cols:
+                low_txt = st.text_input(
+                    "Lower bound (≥) — empty = -inf",
+                    key=f"{key_prefix}_low_num_{i}",
+                )
+                up_txt = st.text_input(
+                    "Upper bound (≤) — empty = +inf",
+                    key=f"{key_prefix}_up_num_{i}",
+                )
+
+                def _float_or_none(s: str):
+                    s = s.strip()
+                    if not s:
+                        return None
+                    try:
+                        return float(s)
+                    except Exception:
+                        return None
+
+                conditions.append(
+                    NumericRangeCondition(
+                        logic=logic_op,
+                        column=var_i,
+                        low=_float_or_none(low_txt),
+                        up=_float_or_none(up_txt),
+                    )
+                )
+
+            elif var_i in cat_cols:
+                op = st.selectbox(
+                    "Operation",
+                    [
+                        "is one of",
+                        "is not one of",
+                        "contains",
+                        "not contains",
+                        "starts with",
+                        "ends with",
+                        "regex",
+                    ],
+                    key=f"{key_prefix}_op_{i}",
+                )
+                case_sens = st.checkbox(
+                    "Case sensitive",
+                    value=False,
+                    key=f"{key_prefix}_case_{i}",
+                )
+                na_match = st.checkbox(
+                    "Treat NA as match",
+                    value=False,
+                    key=f"{key_prefix}_na_{i}",
+                )
+
+                ser_str = df[var_i].astype(str)
+                uniq = pd.unique(ser_str.dropna())[:2000]
+
+                if op in ["is one of", "is not one of"] and len(uniq) <= 100:
+                    vals = st.multiselect(
+                        "Values",
+                        options=sorted(map(str, uniq)),
+                        key=f"{key_prefix}_vals_{i}",
+                    )
+                elif op in ["is one of", "is not one of"]:
+                    csv = st.text_input(
+                        "Comma-separated values",
+                        key=f"{key_prefix}_vals_csv_{i}",
+                    )
+                    vals = _parse_csv_list(csv)
+                else:
+                    patt = st.text_input(
+                        "Pattern / text",
+                        key=f"{key_prefix}_patt_{i}",
+                    )
+                    vals = [patt]
+
+                conditions.append(
+                    CategoricalCondition(
+                        logic=logic_op,
+                        column=var_i,
+                        op=op,
+                        values=vals,
+                        case_sensitive=case_sens,
+                        na_match=na_match,
+                    )
+                )
+
+    return conditions

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_filters_core.py
+++ b/tests/test_filters_core.py
@@ -1,0 +1,142 @@
+import datetime as dt
+
+import pandas as pd
+
+from filters.core import (
+    CategoricalCondition,
+    DatetimeColumnCondition,
+    DatetimeIndexCondition,
+    NumericRangeCondition,
+    TIME_INDEX_OPTION,
+    build_mask,
+    infer_filterable_columns,
+)
+
+
+def test_infer_filterable_columns_detects_types():
+    df = pd.DataFrame(
+        {
+            "num": [1, 2, 3],
+            "cat": ["a", "b", "c"],
+            "dt": pd.date_range("2022-01-01", periods=3),
+        }
+    )
+    df.index = pd.date_range("2022-02-01", periods=3)
+
+    info = infer_filterable_columns(df)
+
+    assert info["is_datetime_index"] is True
+    assert "dt" in info["datetime"]
+    assert "num" in info["numeric"]
+    assert "cat" in info["categorical"]
+    assert info["options"][0] == TIME_INDEX_OPTION
+
+
+def test_build_mask_datetime_index_condition_handles_bounds_and_tz():
+    idx = pd.date_range("2022-01-01", periods=4, freq="D", tz="UTC")
+    df = pd.DataFrame({"value": [10, 20, 30, 40]}, index=idx)
+
+    cond = DatetimeIndexCondition(
+        logic="AND",
+        low=dt.datetime(2022, 1, 2, 0, 0),
+        up=dt.datetime(2022, 1, 3, 12, 0),
+    )
+
+    mask = build_mask(df, [cond])
+    assert mask.tolist() == [False, True, True, False]
+
+
+def test_build_mask_datetime_column_condition():
+    df = pd.DataFrame(
+        {
+            "ts": [
+                "2022-01-01 00:00:00",
+                "2022-01-02 10:00:00",
+                "2022-01-03 00:00:00",
+            ],
+            "value": [1, 2, 3],
+        }
+    )
+
+    cond = DatetimeColumnCondition(
+        logic="AND",
+        column="ts",
+        low=dt.datetime(2022, 1, 2),
+        up=dt.datetime(2022, 1, 2, 12, 0),
+    )
+
+    mask = build_mask(df, [cond])
+    assert mask.tolist() == [False, True, False]
+
+
+def test_build_mask_numeric_range_condition():
+    df = pd.DataFrame({"num": [1, 2, 3, 4], "num_str": ["1", "2", "3", "4"]})
+
+    cond = NumericRangeCondition(
+        logic="AND",
+        column="num_str",
+        low=1.5,
+        up=3.5,
+    )
+
+    mask = build_mask(df, [cond])
+    assert mask.tolist() == [False, True, True, False]
+
+
+def test_build_mask_categorical_operations_and_logic():
+    df = pd.DataFrame(
+        {
+            "cat": ["apple", "banana", "pear", "plum"],
+            "flag": ["yes", "no", "yes", "no"],
+        }
+    )
+
+    cond1 = CategoricalCondition(
+        logic="AND",
+        column="cat",
+        op="contains",
+        values=["ap"],
+        case_sensitive=False,
+        na_match=False,
+    )
+    cond2 = CategoricalCondition(
+        logic="OR",
+        column="flag",
+        op="is one of",
+        values=["yes"],
+        case_sensitive=False,
+        na_match=False,
+    )
+
+    mask = build_mask(df, [cond1, cond2])
+    # cond1 matches "apple"; cond2 OR adds rows with flag == yes
+    assert mask.tolist() == [True, False, True, False]
+
+
+def test_build_mask_regex_and_na_handling():
+    df = pd.DataFrame(
+        {
+            "cat": pd.Series(["alpha", "beta", "gamma", pd.NA], dtype="string"),
+        }
+    )
+
+    cond_regex = CategoricalCondition(
+        logic="AND",
+        column="cat",
+        op="regex",
+        values=["^a"],
+        case_sensitive=False,
+        na_match=False,
+    )
+    cond_na = CategoricalCondition(
+        logic="OR",
+        column="cat",
+        op="is one of",
+        values=["delta"],
+        case_sensitive=False,
+        na_match=True,
+    )
+
+    mask = build_mask(df, [cond_regex, cond_na])
+    # Regex matches "alpha"; OR condition with na_match=True keeps string NA
+    assert mask.tolist() == [True, False, False, True]


### PR DESCRIPTION
## Summary
- extract filter inference, condition dataclasses, and mask builder into `filters/core`
- add a Streamlit helper in `filters/ui` to render filter controls while preserving widget keys
- update `main.py` to use the new helpers and add unit tests that validate filter behavior across data types

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de1af5a2708329a1a7b50d46106577