### PR TITLE
Ensure scenario presets capture histogram selections

### DIFF
--- a/scenario_state.py
+++ b/scenario_state.py
@@ -1,0 +1,70 @@
+"""Utilities for serialising and restoring Streamlit session widget state."""
+
+from __future__ import annotations
+
+import datetime as _dt
+from typing import Any, Dict, Mapping, MutableMapping, Sequence
+
+import numpy as np
+import pandas as pd
+
+
+SCENARIO_WIDGET_PREFIXES: Sequence[str] = (
+    "overview_",
+    "mlc_",
+    "hist_",
+    "sc_",
+    "sc2_",
+    "rw_",
+    "der_",
+)
+
+
+def json_safe_value(value: Any) -> Any:
+    """Convert complex values to JSON-serialisable equivalents."""
+
+    if isinstance(value, (np.integer,)):
+        return int(value)
+    if isinstance(value, (np.floating,)):
+        return float(value)
+    if isinstance(value, (np.bool_,)):
+        return bool(value)
+    if isinstance(value, (pd.Timestamp, _dt.datetime)):
+        return value.isoformat()
+    if isinstance(value, (_dt.date,)):
+        return value.isoformat()
+    if isinstance(value, (_dt.time,)):
+        return value.isoformat()
+    if isinstance(value, list):
+        return [json_safe_value(v) for v in value]
+    if isinstance(value, tuple):
+        return [json_safe_value(v) for v in value]
+    if isinstance(value, set):
+        return [json_safe_value(v) for v in sorted(value)]
+    if isinstance(value, dict):
+        return {str(k): json_safe_value(v) for k, v in value.items()}
+    return value
+
+
+def collect_widget_state(
+    session_state: Mapping[str, Any],
+    prefixes: Sequence[str] = SCENARIO_WIDGET_PREFIXES,
+) -> Dict[str, Any]:
+    """Filter widget entries that should be persisted into a session preset."""
+
+    saved: Dict[str, Any] = {}
+    for key, value in session_state.items():
+        if any(key.startswith(prefix) for prefix in prefixes):
+            saved[key] = json_safe_value(value)
+    return saved
+
+
+def apply_widget_state(
+    widget_state: Mapping[str, Any],
+    session_state: MutableMapping[str, Any],
+) -> None:
+    """Populate ``session_state`` with persisted widget values."""
+
+    for key, value in widget_state.items():
+        session_state[key] = value
+

--- a/tests/test_scenario_state.py
+++ b/tests/test_scenario_state.py
@@ -1,0 +1,33 @@
+from scenario_state import apply_widget_state, collect_widget_state
+
+
+def test_collect_widget_state_includes_histogram_selection():
+    session_state = {
+        "hist_cols_main": ["colA", "colB"],
+        "hist_binmode": "Fixed width",
+        "hist_width_input": 2.5,
+        "unrelated": "value",
+    }
+
+    collected = collect_widget_state(session_state)
+
+    assert collected == {
+        "hist_cols_main": ["colA", "colB"],
+        "hist_binmode": "Fixed width",
+        "hist_width_input": 2.5,
+    }
+
+
+def test_apply_widget_state_overwrites_existing_values():
+    widget_state = {
+        "hist_cols_main": ["colA"],
+        "sc_x": "colX",
+    }
+    session_state = {
+        "hist_cols_main": ["colB"],
+    }
+
+    apply_widget_state(widget_state, session_state)
+
+    assert session_state["hist_cols_main"] == ["colA"]
+    assert session_state["sc_x"] == "colX"


### PR DESCRIPTION
## Summary
- factor widget state serialisation helpers into a dedicated module that captures all prefixed controls, including histogram selections
- reuse the new helpers when exporting/importing scenarios so histogram column choices persist in saved JSON
- add regression tests covering widget state collection and restore behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e687237a50832992283b58fb8acae4